### PR TITLE
Fix publisher id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ```
 plugins = {
     ["plugin.cas"] = {
-        publisherId = "com.cleveradssolution",
+        publisherId = "com.cleveradssolutions",
     },
 },
 ```


### PR DESCRIPTION
The correct published id should be `com.cleveradssolutions`. According to the Solar2D plugin directory https://plugins.solar2d.com